### PR TITLE
Add admin page to delete a message

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,136 @@
+<!-- templates/admin.html -->
+{% extends "base.html" %}
+
+{% block title %}Admin - {{ room.code }}{% endblock %}
+
+{% block content %}
+<div class="main tutor">
+  <div class="panel">
+    <div class="section">
+      <div class="row">
+        <h1>Admin - {{ room.description or room.code }}</h1>
+      </div>
+      <div class="row2 url">
+        <span class="url">Message Management</span>
+      </div>
+    </div>
+    
+    <div class="section">
+      <div class="section-gap"></div>
+      <div class="row">
+        <h2>Messages (<span id="message-count">{{ room.messages|length }}</span>)</h2>
+      </div>
+      <div class="row">
+        <button onclick="refreshMessages()" class="button2">Refresh</button>
+        <span class="col-gap"></span>
+        <button onclick="window.close()" class="button3">Close Admin</button>
+      </div>
+    </div>
+    
+    <div class="section">
+      <div id="messages-container">
+        <!-- Messages will be loaded here -->
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const roomCode = '{{ room.code }}';
+
+function deleteMessage(messageId, messagePreview) {
+    if (!confirm(`Delete message: "${messagePreview}"?`)) {
+        return;
+    }
+    
+    fetch(`/${roomCode}/delete-message/${messageId}`, {
+        method: 'POST'
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            refreshMessages();
+        } else {
+            alert('Failed to delete message');
+        }
+    })
+    .catch(error => {
+        console.error('Error deleting message:', error);
+        alert('Error deleting message');
+    });
+}
+
+function refreshMessages() {
+    fetch(`/${roomCode}/get-messages`)
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            displayMessages(data.messages);
+            document.getElementById('message-count').textContent = data.messages.length;
+        }
+    })
+    .catch(error => {
+        console.error('Error fetching messages:', error);
+    });
+}
+
+function displayMessages(messages) {
+    const container = document.getElementById('messages-container');
+    
+    if (messages.length === 0) {
+        container.innerHTML = '<div class="row">No messages yet</div>';
+        return;
+    }
+    
+    // Get first message timestamp as baseline (before reversing)
+    const firstMessageTime = new Date(messages[0].timestamp);
+    
+    let html = '';
+    messages.reverse();    
+    messages.forEach(message => {
+        const timestamp = new Date(message.timestamp).toLocaleTimeString();
+        const messageTime = new Date(message.timestamp);
+        const isSystemMessage = message.learner_id === 'SYSTEM';
+        const messageClass = isSystemMessage ? 'system-message' : 'team-message';
+        
+        // Calculate minutes since first message
+        const minutesSinceFirst = Math.floor((messageTime - firstMessageTime) / (1000 * 60));
+        const timingSuffix = minutesSinceFirst === 0 ? '' : `+${minutesSinceFirst}m`;
+        
+        // Create preview for confirmation dialog (first 50 chars)
+        const messagePreview = message.message.length > 50 
+            ? message.message.substring(0, 50) + '...'
+            : message.message;
+        
+        html += `
+            <div class="message-container ${messageClass}" style="position: relative;">
+                <div class="message-header" style="display: flex; justify-content: space-between; align-items: center;">
+                    <span>${message.learner_name} - ${timestamp}</span>
+                    <div>
+                        <span style="color: #999; font-size: 0.8em; font-weight: normal; margin-right: 10px;">${timingSuffix}</span>
+                        <button onclick="deleteMessage('${message.id}', '${messagePreview.replace(/'/g, "\\'")}')" 
+                                class="button2" 
+                                style="font-size: 0.8em; padding: 2px 8px; background-color: #ff6b6b; color: white;">
+                            Delete
+                        </button>
+                    </div>
+                </div>
+                <div class="message-text">${message.message}</div>
+                <div style="font-size: 0.7em; color: #999; margin-top: 5px;">
+                    ID: ${message.id}
+                </div>
+            </div>
+        `;
+    });
+    
+    container.innerHTML = html;
+}
+
+// Load messages on page load
+document.addEventListener('DOMContentLoaded', function() {
+    refreshMessages();
+});
+</script>
+{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -22,8 +22,6 @@
       </div>
       <div class="row">
         <button onclick="refreshMessages()" class="button2">Refresh</button>
-        <span class="col-gap"></span>
-        <button onclick="window.close()" class="button3">Close Admin</button>
       </div>
     </div>
     

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -15,6 +15,7 @@
       </div>
     </div>
     
+    <div class="row-gap"></div>
     <div class="section">
       <div class="section-gap"></div>
       <div class="row">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -15,9 +15,7 @@
       </div>
     </div>
     
-    <div class="row-gap"></div>
     <div class="section">
-      <div class="section-gap"></div>
       <div class="row">
         <h2>Messages (<span id="message-count">{{ room.messages|length }}</span>)</h2>
       </div>
@@ -26,6 +24,7 @@
       </div>
     </div>
     
+    <div class="row-gap"></div>
     <div class="section">
       <div id="messages-container">
         <!-- Messages will be loaded here -->


### PR DESCRIPTION
## Pull Request: Add Admin Page for Selective Message Deletion

relates to issue #1 

### Problem
Currently can only clear ALL messages via "Clear All Messages" button. Need ability to delete individual messages (typos, gibberish, accidental sends) without losing entire conversation history.

### Solution
Added `/ROOMCODE/admin` page for selective message management:

**New Routes:**
- `GET /<room_code>/admin` - Admin interface
- `POST /<room_code>/delete-message/<message_id>` - Delete specific message

**New Template:**
- `admin.html` - Message list with individual delete buttons

### Features
- **Individual delete buttons** with confirmation dialog
- **Message preview** in confirmation ("Delete: 'sdhstter'?")
- **Timing analysis** (same +Xm display as tutor page)
- **No changes** to existing tutor/team pages
- **Auto-refresh** updates message count after deletion

### Usage
1. Open `/ROOMCODE/admin` in new tab during exercise
2. Delete unwanted messages (typos, gibberish)
3. Close admin tab
4. Existing pages show updated messages on next refresh

### Benefits
- **Surgical deletion** - remove specific problems without losing conversation
- **Clean separation** - admin functionality separate from training interface
- **Zero disruption** - existing workflow unchanged

**Testing:** Verified deletion works correctly and existing pages update properly.